### PR TITLE
Removing { } for Folding support

### DIFF
--- a/NotepadPlusPlus/KerboScript_frozen.xml
+++ b/NotepadPlusPlus/KerboScript_frozen.xml
@@ -13,7 +13,7 @@
             <Keywords name="Numbers, suffix1"></Keywords>
             <Keywords name="Numbers, suffix2"></Keywords>
             <Keywords name="Numbers, range"></Keywords>
-            <Keywords name="Operators1">+ - * / ^ : ( ) , = &lt; &gt; &lt;&gt; &gt;= &lt;= [ ] { }.</Keywords>
+            <Keywords name="Operators1">+ - * / ^ : ( ) , = &lt; &gt; &lt;&gt; &gt;= &lt;= [ ] .</Keywords>
             <Keywords name="Operators2">AND OR NOT ON OFF</Keywords>
             <Keywords name="Folders in code1, open">{</Keywords>
             <Keywords name="Folders in code1, middle"></Keywords>


### PR DESCRIPTION
Removed { and } from Operatrors1 tag so that the foldings function of N++ is working